### PR TITLE
implement core token mechanics including minting, transfer, approval, and contract admin controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+**/settings/Mainnet.toml
+**/settings/Testnet.toml
+.requirements/
+history.txt

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+
+{
+    "deno.enable": true,
+    "files.eol": "\n"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "check contracts",
+            "group": "test",
+            "type": "shell",
+            "command": "clarinet check"
+        },
+        {
+            "label": "test contracts",
+            "group": "test",
+            "type": "shell",
+            "command": "clarinet test"
+        }
+    ]
+}

--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -1,0 +1,23 @@
+[project]
+name = "STX-AstraMint"
+authors = []
+description = ""
+telemetry = true
+requirements = []
+cache_dir = "/home/runner/workspace/STX-AstraMint/./.requirements"
+boot_contracts = ["pox", "costs-v2", "bns"]
+[contracts.STX-AstraMint]
+path = "contracts/STX-AstraMint.clar"
+
+[repl]
+costs_version = 2
+parser_version = 2
+
+[repl.analysis]
+passes = ["check_checker"]
+
+[repl.analysis.check_checker]
+strict = false
+trusted_sender = false
+trusted_caller = false
+callee_filter = false

--- a/contracts/STX-AstraMint.clar
+++ b/contracts/STX-AstraMint.clar
@@ -116,3 +116,155 @@
         (var-set last-event-id (+ (var-get last-event-id) u1))
         (print { type: "burn", id: (var-get last-event-id), from: from, amount: amount })))
 
+
+
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;; Read-Only Functions ;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(define-read-only (get-name)
+    (ok (var-get token-name)))
+
+(define-read-only (get-symbol)
+    (ok (var-get token-symbol)))
+
+(define-read-only (get-decimals)
+    (ok (var-get token-decimals)))
+
+(define-read-only (get-total-supply)
+    (ok (var-get total-supply)))
+
+(define-read-only (get-balance (account principal))
+    (ok (ft-get-balance stellar account)))
+
+(define-read-only (get-allowance (owner principal) (spender principal))
+    (match (map-get? allowances { owner: owner, spender: spender })
+        allowance-data (let ((current-height stacks-block-height))
+            (if (>= current-height (get expiry allowance-data))
+                (ok u0)
+                (ok (get amount allowance-data))))
+        (ok u0)))
+
+(define-read-only (is-locked (address principal))
+    (match (map-get? locked-tokens { address: address })
+        lock-data (> (get unlock-height lock-data) stacks-block-height)
+        false))
+
+
+
+;;;;; PUBLIC FUNCTIONS ;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Administrative Functions
+(define-public (initialize (name (string-ascii 32)) (symbol (string-ascii 10)) (decimals uint))
+    (begin
+        (asserts! (is-contract-owner) ERR-NOT-AUTHORIZED)
+        (asserts! (not (var-get initialized)) ERR-ALREADY-INITIALIZED)
+
+        ;; Validate name
+        (asserts! (>= (len name) u1) ERR-INVALID-AMOUNT)  ;; Ensure name is not empty
+        (asserts! (<= (len name) u32) ERR-INVALID-AMOUNT)  ;; Extra safety check for length
+
+        ;; Validate symbol
+        (asserts! (>= (len symbol) u1) ERR-INVALID-AMOUNT)  ;; Ensure symbol is not empty
+        (asserts! (<= (len symbol) u10) ERR-INVALID-AMOUNT)  ;; Extra safety check for length
+
+        ;; Validate decimals (common values are 6, 8, or 18)
+        (asserts! (<= decimals u18) ERR-INVALID-AMOUNT)  ;; Ensure decimals is reasonable
+        (asserts! (>= decimals u0) ERR-INVALID-AMOUNT)   ;; Ensure decimals is non-negative
+
+        ;; After validation, set the values
+        (var-set token-name name)
+        (var-set token-symbol symbol)
+        (var-set token-decimals decimals)
+        (var-set initialized true)
+        (ok true)))
+
+
+(define-public (set-contract-owner (new-owner principal))
+    (begin
+        (asserts! (is-contract-owner) ERR-NOT-AUTHORIZED)
+        (asserts! (not (is-eq new-owner (var-get contract-owner))) ERR-INVALID-RECIPIENT)
+        (var-set contract-owner new-owner)
+        (ok true)))
+
+(define-public (pause)
+    (begin
+        (asserts! (is-contract-owner) ERR-NOT-AUTHORIZED)
+        (var-set paused true)
+        (ok true)))
+
+(define-public (unpause)
+    (begin
+        (asserts! (is-contract-owner) ERR-NOT-AUTHORIZED)
+        (var-set paused false)
+        (ok true)))
+
+;; Token Operations
+(define-public (mint (amount uint) (recipient principal))
+    (begin
+        (asserts! (is-contract-owner) ERR-NOT-AUTHORIZED)
+        (asserts! (> amount u0) ERR-INVALID-AMOUNT)
+        (asserts! (is-valid-recipient recipient) ERR-INVALID-RECIPIENT)
+        (try! (check-initialized))
+        (try! (check-not-paused))
+
+        (let ((new-supply (try! (safe-add (var-get total-supply) amount))))
+            (asserts! (<= new-supply MAX-SUPPLY) ERR-MAX-SUPPLY-REACHED)
+
+            (try! (ft-mint? stellar amount recipient))
+            (var-set total-supply new-supply)
+
+            (map-set governance-tokens
+                { holder: recipient }
+                { 
+                    voting-power: (unwrap! (safe-add 
+                        (default-to u0 (get voting-power (map-get? governance-tokens { holder: recipient }))) 
+                        amount) ERR-OVERFLOW),
+                    last-vote-height: stacks-block-height 
+                })
+            (ok true))))
+
+(define-public (transfer (amount uint) (recipient principal))
+    (begin
+        (asserts! (> amount u0) ERR-INVALID-AMOUNT)
+        (asserts! (is-valid-recipient recipient) ERR-INVALID-RECIPIENT)
+        (try! (check-initialized))
+        (try! (check-not-paused))
+        (asserts! (not (is-locked tx-sender)) ERR-NOT-AUTHORIZED)
+
+        (let ((sender-balance (unwrap! (get-balance tx-sender) ERR-INSUFFICIENT-BALANCE)))
+            (asserts! (>= sender-balance amount) ERR-INSUFFICIENT-BALANCE)
+
+            (try! (ft-transfer? stellar amount tx-sender recipient))
+
+            (map-set governance-tokens
+                { holder: tx-sender }
+                { 
+                    voting-power: (- sender-balance amount),
+                    last-vote-height: stacks-block-height 
+                })
+
+            (map-set governance-tokens
+                { holder: recipient }
+                { 
+                    voting-power: (unwrap! (safe-add 
+                        (default-to u0 (get voting-power (map-get? governance-tokens { holder: recipient }))) 
+                        amount) ERR-OVERFLOW),
+                    last-vote-height: stacks-block-height 
+                })
+            (ok true))))
+
+(define-public (approve (amount uint) (spender principal) (expiry uint))
+    (begin
+        (asserts! (> amount u0) ERR-INVALID-AMOUNT)
+        (asserts! (not (is-eq spender tx-sender)) ERR-INVALID-SPENDER)
+        (asserts! (>= expiry stacks-block-height) ERR-EXPIRED-ALLOWANCE)
+        (try! (check-initialized))
+        (try! (check-not-paused))
+
+        (map-set allowances
+            { owner: tx-sender, spender: spender }
+            { amount: amount, expiry: expiry })
+        (ok true)))

--- a/settings/Devnet.toml
+++ b/settings/Devnet.toml
@@ -1,0 +1,126 @@
+[network]
+name = "devnet"
+deployment_fee_rate = 10
+
+[accounts.deployer]
+mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
+balance = 100_000_000_000_000
+# secret_key: 753b7cc01a1a2e86221266a154af739463fce51219d97e4f856cd7200c3bd2a601
+# stx_address: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+# btc_address: mqVnk6NPRdhntvfm4hh9vvjiRkFDUuSYsH
+
+[accounts.wallet_1]
+mnemonic = "sell invite acquire kitten bamboo drastic jelly vivid peace spawn twice guilt pave pen trash pretty park cube fragile unaware remain midnight betray rebuild"
+balance = 100_000_000_000_000
+# secret_key: 7287ba251d44a4d3fd9276c88ce34c5c52a038955511cccaf77e61068649c17801
+# stx_address: ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5
+# btc_address: mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC
+
+[accounts.wallet_2]
+mnemonic = "hold excess usual excess ring elephant install account glad dry fragile donkey gaze humble truck breeze nation gasp vacuum limb head keep delay hospital"
+balance = 100_000_000_000_000
+# secret_key: 530d9f61984c888536871c6573073bdfc0058896dc1adfe9a6a10dfacadc209101
+# stx_address: ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG
+# btc_address: muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG
+
+[accounts.wallet_3]
+mnemonic = "cycle puppy glare enroll cost improve round trend wrist mushroom scorpion tower claim oppose clever elephant dinosaur eight problem before frozen dune wagon high"
+balance = 100_000_000_000_000
+# secret_key: d655b2523bcd65e34889725c73064feb17ceb796831c0e111ba1a552b0f31b3901
+# stx_address: ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC
+# btc_address: mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7
+
+[accounts.wallet_4]
+mnemonic = "board list obtain sugar hour worth raven scout denial thunder horse logic fury scorpion fold genuine phrase wealth news aim below celery when cabin"
+balance = 100_000_000_000_000
+# secret_key: f9d7206a47f14d2870c163ebab4bf3e70d18f5d14ce1031f3902fbbc894fe4c701
+# stx_address: ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND
+# btc_address: mg1C76bNTutiCDV3t9nWhZs3Dc8LzUufj8
+
+[accounts.wallet_5]
+mnemonic = "hurry aunt blame peanut heavy update captain human rice crime juice adult scale device promote vast project quiz unit note reform update climb purchase"
+balance = 100_000_000_000_000
+# secret_key: 3eccc5dac8056590432db6a35d52b9896876a3d5cbdea53b72400bc9c2099fe801
+# stx_address: ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB
+# btc_address: mweN5WVqadScHdA81aATSdcVr4B6dNokqx
+
+[accounts.wallet_6]
+mnemonic = "area desk dutch sign gold cricket dawn toward giggle vibrant indoor bench warfare wagon number tiny universe sand talk dilemma pottery bone trap buddy"
+balance = 100_000_000_000_000
+# secret_key: 7036b29cb5e235e5fd9b09ae3e8eec4404e44906814d5d01cbca968a60ed4bfb01
+# stx_address: ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0
+# btc_address: mzxXgV6e4BZSsz8zVHm3TmqbECt7mbuErt
+
+[accounts.wallet_7]
+mnemonic = "prevent gallery kind limb income control noise together echo rival record wedding sense uncover school version force bleak nuclear include danger skirt enact arrow"
+balance = 100_000_000_000_000
+# secret_key: b463f0df6c05d2f156393eee73f8016c5372caa0e9e29a901bb7171d90dc4f1401
+# stx_address: ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ
+# btc_address: n37mwmru2oaVosgfuvzBwgV2ysCQRrLko7
+
+[accounts.wallet_8]
+mnemonic = "female adjust gallery certain visit token during great side clown fitness like hurt clip knife warm bench start reunion globe detail dream depend fortune"
+balance = 100_000_000_000_000
+# secret_key: 6a1a754ba863d7bab14adbbc3f8ebb090af9e871ace621d3e5ab634e1422885e01
+# stx_address: ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP
+# btc_address: n2v875jbJ4RjBnTjgbfikDfnwsDV5iUByw
+
+[accounts.wallet_9]
+mnemonic = "shadow private easily thought say logic fault paddle word top book during ignore notable orange flight clock image wealth health outside kitten belt reform"
+balance = 100_000_000_000_000
+# secret_key: de433bdfa14ec43aa1098d5be594c8ffb20a31485ff9de2923b2689471c401b801
+# stx_address: STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6
+# btc_address: mjSrB3wS4xab3kYqFktwBzfTdPg367ZJ2d
+
+[devnet]
+disable_stacks_explorer = false
+disable_stacks_api = false
+# disable_bitcoin_explorer = true
+# working_dir = "tmp/devnet"
+# stacks_node_events_observers = ["host.docker.internal:8002"]
+# miner_mnemonic = "twice kind fence tip hidden tilt action fragile skin nothing glory cousin green tomorrow spring wrist shed math olympic multiply hip blue scout claw"
+# miner_derivation_path = "m/44'/5757'/0'/0/0"
+# orchestrator_port = 20445
+# bitcoin_node_p2p_port = 18444
+# bitcoin_node_rpc_port = 18443
+# bitcoin_node_username = "devnet"
+# bitcoin_node_password = "devnet"
+# bitcoin_controller_block_time = 30_000
+# stacks_node_rpc_port = 20443
+# stacks_node_p2p_port = 20444
+# stacks_api_port = 3999
+# stacks_api_events_port = 3700
+# bitcoin_explorer_port = 8001
+# stacks_explorer_port = 8000
+# postgres_port = 5432
+# postgres_username = "postgres"
+# postgres_password = "postgres"
+# postgres_database = "postgres"
+# bitcoin_node_image_url = "quay.io/hirosystems/bitcoind:devnet-v2"
+# stacks_node_image_url = "localhost:5000/stacks-node:devnet-v2"
+# stacks_api_image_url = "blockstack/stacks-blockchain-api:latest"
+# stacks_explorer_image_url = "blockstack/explorer:latest"
+# bitcoin_explorer_image_url = "quay.io/hirosystems/bitcoin-explorer:devnet"
+# postgres_image_url = "postgres:alpine"
+
+# Send some stacking orders
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 3
+duration = 12
+wallet = "wallet_1"
+slots = 2
+btc_address = "mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 3
+duration = 12
+wallet = "wallet_2"
+slots = 1
+btc_address = "muYdXKmX9bByAueDe6KFfHd5Ff1gdN9ErG"
+
+[[devnet.pox_stacking_orders]]
+start_at_cycle = 3
+duration = 12
+wallet = "wallet_3"
+slots = 1
+btc_address = "mvZtbibDAAA3WLpY7zXXFqRa3T4XSknBX7"

--- a/tests/STX-AstraMint_test.ts
+++ b/tests/STX-AstraMint_test.ts
@@ -1,0 +1,26 @@
+
+import { Clarinet, Tx, Chain, Account, types } from 'https://deno.land/x/clarinet@v0.31.0/index.ts';
+import { assertEquals } from 'https://deno.land/std@0.90.0/testing/asserts.ts';
+
+Clarinet.test({
+    name: "Ensure that <...>",
+    async fn(chain: Chain, accounts: Map<string, Account>) {
+        let block = chain.mineBlock([
+            /* 
+             * Add transactions with: 
+             * Tx.contractCall(...)
+            */
+        ]);
+        assertEquals(block.receipts.length, 0);
+        assertEquals(block.height, 2);
+
+        block = chain.mineBlock([
+            /* 
+             * Add transactions with: 
+             * Tx.contractCall(...)
+            */
+        ]);
+        assertEquals(block.receipts.length, 0);
+        assertEquals(block.height, 3);
+    },
+});


### PR DESCRIPTION
**Pull Request Description:**

### Summary

This PR delivers the **core public and read-only functionality** for the STX-AstraMint token contract. Building upon the previously defined structures and constants, this update finalizes the essential ERC-20-style mechanisms with enhanced governance, safety, and permissioned control — ensuring token compliance, security, and modularity.

---

### 🔍 Read-Only Functions

These functions allow safe, gas-free inspection of contract state:

* `get-name` / `get-symbol` / `get-decimals`: Return token metadata.
* `get-total-supply`: Returns circulating token supply.
* `get-balance`: Fetches a principal’s current token balance.
* `get-allowance`: Returns the remaining allowance if still valid (non-expired).
* `is-locked`: Checks if tokens are locked (time-bound restriction) for a principal.

---

### 🧩 Public Functions

#### 🔧 Administrative Controls

* `initialize(name, symbol, decimals)`:
  Sets token metadata and marks the contract as initialized. Only callable once by the contract owner. Ensures name/symbol/decimal validation (non-empty, length bounds, decimal caps).

* `set-contract-owner(new-owner)`:
  Transfers contract ownership to another principal (must be different from the current one).

* `pause` / `unpause`:
  Allow the owner to pause and unpause critical functions like transfer/mint/approve to mitigate risk during emergencies or audits.

#### 💸 Token Mechanics

* `mint(amount, recipient)`:
  Owner-only function that mints tokens to a valid recipient. Enforces:

  * Initialization and unpaused checks.
  * Cap on `MAX-SUPPLY`.
  * Voting power updates in the `governance-tokens` map.

* `transfer(amount, recipient)`:
  Enables users to transfer tokens, with safeguards:

  * Cannot transfer to oneself or restricted addresses.
  * Sender must not be locked.
  * Governance voting power is updated for both sender and recipient post-transfer.

* `approve(amount, spender, expiry)`:
  Allows a token holder to approve a spender with a specific expiry time. Safeguards:

  * Rejects self-approvals.
  * Requires expiry to be in the future.
  * Updates `allowances` map.

---
